### PR TITLE
feat(code): create initial framework for bytecodes

### DIFF
--- a/pkg/code/code.go
+++ b/pkg/code/code.go
@@ -1,0 +1,57 @@
+// The Monkey Language bytecode definition
+package code
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+type Instructions []byte
+type Opcode byte
+
+const (
+	OpConstant Opcode = iota
+)
+
+type Definition struct {
+	Name          string
+	OperandWidths []int
+}
+
+var definitions = map[Opcode]*Definition{
+	OpConstant: {"OpConstant", []int{2}},
+}
+
+func Lookup(op byte) (*Definition, error) {
+	if def, ok := definitions[Opcode(op)]; ok {
+		return def, nil
+	}
+	return nil, fmt.Errorf("opcode %d undefined", op)
+}
+
+func Make(op Opcode, operands ...int) []byte {
+	def, ok := definitions[op]
+	if !ok {
+		return []byte{}
+	}
+
+	instructionsLen := 1
+	for _, w := range def.OperandWidths {
+		instructionsLen += w
+	}
+
+	instruction := make([]byte, instructionsLen)
+	instruction[0] = byte(op)
+
+	offset := 1
+	for i, o := range operands {
+		width := def.OperandWidths[i]
+		switch width {
+		case 2:
+			binary.BigEndian.PutUint16(instruction[offset:], uint16(o))
+		}
+		offset += width
+	}
+
+	return instruction
+}

--- a/pkg/code/code_test.go
+++ b/pkg/code/code_test.go
@@ -1,0 +1,29 @@
+// The Monkey Language bytecode definition unit tests
+package code
+
+import "testing"
+
+func TestMake(t *testing.T) {
+	tests := []struct {
+		op       Opcode
+		operands []int
+		expected []byte
+	}{
+		{OpConstant, []int{65534}, []byte{byte(OpConstant), 255, 254}},
+	}
+
+	for _, tt := range tests {
+		instruction := Make(tt.op, tt.operands...)
+
+		if len(instruction) != len(tt.expected) {
+			t.Errorf("instruction has wrong length. want=%d, got=%d",
+				len(tt.expected), len(instruction))
+		}
+
+		for i, b := range tt.expected {
+			if instruction[i] != tt.expected[i] {
+				t.Errorf("wrong byte at pos %d. want=%d, got=%d", i, b, instruction[i])
+			}
+		}
+	}
+}


### PR DESCRIPTION
The initial implementation introduces the definitions for the machine
opcodes and some functions for converting instructions.  To start, only
OpConstant is defined.  Additional instructions will be added
iteratively.

The unit test validates that creation of an OpConstant with a two-byte
wide operand can be successfully created and encoded in big-endian
notation.
