### PR TITLE
feat(compiler): initial compiler framework implemented

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/freddiehaddad/monkey.compiler
 
 go 1.20
+
+require github.com/freddiehaddad/monkey.interpreter v0.0.0-20230329234316-a6be99b8a73c

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/freddiehaddad/monkey.interpreter v0.0.0-20230329234316-a6be99b8a73c h1:YH+0fcp1ueEKjA517x9+ljM4DMWPsam2lkuhflqJf/g=
+github.com/freddiehaddad/monkey.interpreter v0.0.0-20230329234316-a6be99b8a73c/go.mod h1:MEco7wdmKlJ1Cn9dp07QadWC6KC4xOPthbaiopfHtBY=

--- a/pkg/code/code.go
+++ b/pkg/code/code.go
@@ -2,6 +2,7 @@
 package code
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 )
@@ -9,14 +10,14 @@ import (
 type Instructions []byte
 type Opcode byte
 
-const (
-	OpConstant Opcode = iota
-)
-
 type Definition struct {
 	Name          string
 	OperandWidths []int
 }
+
+const (
+	OpConstant Opcode = iota
+)
 
 var definitions = map[Opcode]*Definition{
 	OpConstant: {"OpConstant", []int{2}},
@@ -54,4 +55,61 @@ func Make(op Opcode, operands ...int) []byte {
 	}
 
 	return instruction
+}
+
+func ReadOperands(def *Definition, ins Instructions) ([]int, int) {
+	operands := make([]int, len(def.OperandWidths))
+	offset := 0
+
+	for i, width := range def.OperandWidths {
+		switch width {
+		case 2:
+			operands[i] = int(ReadUint16(ins[offset:]))
+		}
+
+		offset += width
+	}
+
+	return operands, offset
+}
+
+func ReadUint16(ins Instructions) uint16 {
+	return binary.BigEndian.Uint16(ins)
+}
+
+func (ins Instructions) String() string {
+	var out bytes.Buffer
+
+	i := 0
+	for i < len(ins) {
+		def, err := Lookup(ins[i])
+		if err != nil {
+			fmt.Fprintf(&out, "ERROR: %s\n", err)
+			continue
+		}
+
+		operands, read := ReadOperands(def, ins[i+1:])
+
+		fmt.Fprintf(&out, "%04d %s\n", i, ins.fmtInstruction(def, operands))
+
+		i += 1 + read
+	}
+
+	return out.String()
+}
+
+func (ins Instructions) fmtInstruction(def *Definition, operands []int) string {
+	operandCount := len(def.OperandWidths)
+
+	if len(operands) != operandCount {
+		return fmt.Sprintf("ERROR: operand len %d does not match defined %d\n",
+			len(operands), operandCount)
+	}
+
+	switch operandCount {
+	case 1:
+		return fmt.Sprintf("%s %d", def.Name, operands[0])
+	}
+
+	return fmt.Sprintf("ERROR: unhandled operandCount for %s\n", def.Name)
 }

--- a/pkg/code/code_test.go
+++ b/pkg/code/code_test.go
@@ -28,3 +28,57 @@ func TestMake(t *testing.T) {
 		}
 	}
 }
+
+func TestInstructionsString(t *testing.T) {
+	instructions := []Instructions{
+		Make(OpConstant, 1),
+		Make(OpConstant, 2),
+		Make(OpConstant, 65535),
+	}
+
+	expected := `0000 OpConstant 1
+0003 OpConstant 2
+0006 OpConstant 65535
+`
+
+	concatenated := Instructions{}
+	for _, ins := range instructions {
+		concatenated = append(concatenated, ins...)
+	}
+
+	if concatenated.String() != expected {
+		t.Errorf("instructions wrongly formatted.\nwant=%q\ngot=%q",
+			expected, concatenated.String())
+	}
+}
+
+func TestReadOperands(t *testing.T) {
+	tests := []struct {
+		op        Opcode
+		operands  []int
+		bytesRead int
+	}{
+		{OpConstant, []int{65532}, 2},
+	}
+
+	for _, tt := range tests {
+		instruction := Make(tt.op, tt.operands...)
+
+		def, err := Lookup(byte(tt.op))
+		if err != nil {
+			t.Fatalf("definition not found: %q", err)
+		}
+
+		operandsRead, n := ReadOperands(def, instruction[1:])
+		if n != tt.bytesRead {
+			t.Fatalf("n wrong. want=%d, got=%d", tt.bytesRead, n)
+		}
+
+		for i, want := range tt.operands {
+			if operandsRead[i] != want {
+				t.Errorf("operand wrong. want=%d, got=%d",
+					want, operandsRead[i])
+			}
+		}
+	}
+}

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -1,0 +1,77 @@
+// The Monkey Language compiler definition
+package compiler
+
+import (
+	"github.com/freddiehaddad/monkey.compiler/pkg/code"
+	"github.com/freddiehaddad/monkey.interpreter/pkg/ast"
+	"github.com/freddiehaddad/monkey.interpreter/pkg/object"
+)
+
+type Compiler struct {
+	instructions code.Instructions
+	constants    []object.Object
+}
+
+type Bytecode struct {
+	Instructions code.Instructions
+	Constants    []object.Object
+}
+
+func New() *Compiler {
+	return &Compiler{
+		instructions: code.Instructions{},
+		constants:    []object.Object{},
+	}
+}
+
+func (c *Compiler) Compile(node ast.Node) error {
+	switch node := node.(type) {
+	case *ast.Program:
+		for _, s := range node.Statements {
+			if err := c.Compile(s); err != nil {
+				return err
+			}
+		}
+	case *ast.ExpressionStatement:
+		if err := c.Compile(node.Expression); err != nil {
+			return err
+		}
+	case *ast.InfixExpression:
+		if err := c.Compile(node.Left); err != nil {
+			return err
+		}
+		if err := c.Compile(node.Right); err != nil {
+			return err
+		}
+	case *ast.IntegerLiteral:
+		integer := &object.Integer{Value: node.Value}
+		c.emit(code.OpConstant, c.addConstant(integer))
+	}
+
+	return nil
+}
+
+func (c *Compiler) Bytecode() *Bytecode {
+	return &Bytecode{
+		Instructions: c.instructions,
+		Constants:    c.constants,
+	}
+}
+
+func (c *Compiler) addConstant(obj object.Object) int {
+	posNewConstant := len(c.constants)
+	c.constants = append(c.constants, obj)
+	return posNewConstant
+}
+
+func (c *Compiler) emit(op code.Opcode, operands ...int) int {
+	ins := code.Make(op, operands...)
+	pos := c.addInstruction(ins)
+	return pos
+}
+
+func (c *Compiler) addInstruction(ins []byte) int {
+	posNewInstruction := len(c.instructions)
+	c.instructions = append(c.instructions, ins...)
+	return posNewInstruction
+}

--- a/pkg/compiler/compiler_test.go
+++ b/pkg/compiler/compiler_test.go
@@ -1,0 +1,118 @@
+// The Monkey Language compiler definition unit tests
+package compiler
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/freddiehaddad/monkey.compiler/pkg/code"
+	"github.com/freddiehaddad/monkey.interpreter/pkg/ast"
+	"github.com/freddiehaddad/monkey.interpreter/pkg/lexer"
+	"github.com/freddiehaddad/monkey.interpreter/pkg/object"
+	"github.com/freddiehaddad/monkey.interpreter/pkg/parser"
+)
+
+type compilerTestCase struct {
+	input                string
+	expectedConstants    []interface{}
+	expectedInstructions []code.Instructions
+}
+
+func TestIntegerArithmetic(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input:             "1 + 2",
+			expectedConstants: []interface{}{1, 2},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1),
+			},
+		},
+	}
+
+	runCompilerTests(t, tests)
+}
+
+func runCompilerTests(t *testing.T, tests []compilerTestCase) {
+	t.Helper()
+
+	for _, tt := range tests {
+		program := parse(tt.input)
+		compiler := New()
+		if err := compiler.Compile(program); err != nil {
+			t.Fatalf("compiler error: %s", err)
+		}
+
+		bytecode := compiler.Bytecode()
+
+		if err := testInstructions(tt.expectedInstructions,
+			bytecode.Instructions); err != nil {
+			t.Fatalf("testInstructions failed: %s", err)
+		}
+
+		if err := testConstants(t, tt.expectedConstants, bytecode.Constants); err != nil {
+			t.Fatalf("testConstants failed: %s", err)
+		}
+	}
+}
+
+func parse(input string) *ast.Program {
+	l := lexer.New(input)
+	p := parser.New(l)
+	return p.ParseProgram()
+}
+
+func testInstructions(expected []code.Instructions, actual code.Instructions) error {
+	concatenated := concatenateInstructions(expected)
+
+	if len(actual) != len(concatenated) {
+		return fmt.Errorf("wrong instructions length.\nwant=%q\ngot=%q", concatenated, actual)
+	}
+
+	for i, ins := range concatenated {
+		if actual[i] != ins {
+			return fmt.Errorf("wrong instruction at %d.\nwant=%q\ngot=%q", i, concatenated, actual)
+		}
+	}
+
+	return nil
+}
+
+func concatenateInstructions(s []code.Instructions) code.Instructions {
+	out := code.Instructions{}
+
+	for _, ins := range s {
+		out = append(out, ins...)
+	}
+
+	return out
+}
+
+func testConstants(t *testing.T, expected []interface{}, actual []object.Object) error {
+	if len(expected) != len(actual) {
+		return fmt.Errorf("wrong number of constants.\ngot=%d\nwant=%d", len(actual), len(expected))
+	}
+
+	for i, constant := range expected {
+		switch constant := constant.(type) {
+		case int:
+			if err := testIntegerObject(int64(constant), actual[i]); err != nil {
+				return fmt.Errorf("constant %d - testIntegerObject failed: %s", i, err)
+			}
+		}
+	}
+	return nil
+}
+
+func testIntegerObject(expected int64, actual object.Object) error {
+	result, ok := actual.(*object.Integer)
+	if !ok {
+		return fmt.Errorf("object is not Integer. got=%T (%+v)", actual, actual)
+	}
+
+	if result.Value != expected {
+		return fmt.Errorf("object has wrong value. got=%d, want=%d", result.Value, expected)
+	}
+
+	return nil
+}


### PR DESCRIPTION
A framework for opcodes and compiling constant integer literal
expressions is defined along with a suite of tests that cover:

    - creating an instruction
    - decoding an instruction
    - compiling constant expressions
    - storing constants on the stack
    - instruction addresses
