### PR TITLE
feat(vm): add initial vm infrastructure and tests

### DIFF
--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -1,0 +1,65 @@
+// The Monkey Language vm definition
+package vm
+
+import (
+	"fmt"
+
+	"github.com/freddiehaddad/monkey.compiler/pkg/code"
+	"github.com/freddiehaddad/monkey.compiler/pkg/compiler"
+	"github.com/freddiehaddad/monkey.interpreter/pkg/object"
+)
+
+const StackSize = 2048
+
+type VM struct {
+	constants    []object.Object
+	instructions code.Instructions
+
+	stack []object.Object
+	sp    int // Always points to the next value. Top of stack is stack[sp-1]
+}
+
+func New(bytecode *compiler.Bytecode) *VM {
+	return &VM{
+		instructions: bytecode.Instructions,
+		constants:    bytecode.Constants,
+
+		stack: make([]object.Object, StackSize),
+		sp:    0,
+	}
+}
+
+func (vm *VM) StackTop() object.Object {
+	if vm.sp == 0 {
+		return nil
+	}
+	return vm.stack[vm.sp-1]
+}
+
+func (vm *VM) Run() error {
+	for ip := 0; ip < len(vm.instructions); ip++ {
+		op := code.Opcode(vm.instructions[ip])
+
+		switch op {
+		case code.OpConstant:
+			constIndex := code.ReadUint16(vm.instructions[ip+1:])
+			ip += 2
+
+			if err := vm.push(vm.constants[constIndex]); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (vm *VM) push(o object.Object) error {
+	if vm.sp >= StackSize {
+		return fmt.Errorf("stack overflow")
+	}
+
+	vm.stack[vm.sp] = o
+	vm.sp++
+
+	return nil
+}

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -1,0 +1,80 @@
+// The Monkey Language vm definition unit tests
+package vm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/freddiehaddad/monkey.compiler/pkg/compiler"
+	"github.com/freddiehaddad/monkey.interpreter/pkg/ast"
+	"github.com/freddiehaddad/monkey.interpreter/pkg/lexer"
+	"github.com/freddiehaddad/monkey.interpreter/pkg/object"
+	"github.com/freddiehaddad/monkey.interpreter/pkg/parser"
+)
+
+type vmTestCase struct {
+	input    string
+	expected interface{}
+}
+
+func parse(input string) *ast.Program {
+	l := lexer.New(input)
+	p := parser.New(l)
+	return p.ParseProgram()
+}
+
+func testIntegerObject(expected int64, actual object.Object) error {
+	result, ok := actual.(*object.Integer)
+	if !ok {
+		return fmt.Errorf("object is not Integer. got=%T (%+v)", actual, actual)
+	}
+
+	if result.Value != expected {
+		return fmt.Errorf("object has wrong value. got=%d, want=%d", result.Value, expected)
+	}
+
+	return nil
+}
+
+func runVmTests(t *testing.T, tests []vmTestCase) {
+	t.Helper()
+
+	for _, tt := range tests {
+		program := parse(tt.input)
+
+		comp := compiler.New()
+		if err := comp.Compile(program); err != nil {
+			t.Fatalf("compiler error: %s", err)
+		}
+
+		vm := New(comp.Bytecode())
+		if err := vm.Run(); err != nil {
+			t.Fatalf("vm error: %s", err)
+		}
+
+		stackElem := vm.StackTop()
+
+		testExpectedObject(t, tt.expected, stackElem)
+	}
+}
+
+func testExpectedObject(t *testing.T, expected interface{}, actual object.Object) {
+	t.Helper()
+
+	switch expected := expected.(type) {
+	case int:
+		if err := testIntegerObject(int64(expected), actual); err != nil {
+			t.Errorf("testIntegerObject failed: %s", err)
+		}
+	}
+}
+
+func TestIntegerArithmetic(t *testing.T) {
+	tests := []vmTestCase{
+		{"1", 1},
+		{"2", 2},
+		{"1 + 2", 2}, // FIXME
+	}
+
+	runVmTests(t, tests)
+}


### PR DESCRIPTION
The initial VM infrastructure includes a runtime stack and support for
decoding OpConstant instructions.

The initial test infrastructure allows for easily extending the test
cases with the initial tests confirming that OpConstant instructions are
correctly pushed to the runtime stack.
