### PR TITLE
feat(OpAdd): implement the add instruction

### DIFF
--- a/pkg/code/code.go
+++ b/pkg/code/code.go
@@ -17,10 +17,12 @@ type Definition struct {
 
 const (
 	OpConstant Opcode = iota
+	OpAdd
 )
 
 var definitions = map[Opcode]*Definition{
 	OpConstant: {"OpConstant", []int{2}},
+	OpAdd:      {"OpAdd", []int{}},
 }
 
 func Lookup(op byte) (*Definition, error) {
@@ -107,6 +109,8 @@ func (ins Instructions) fmtInstruction(def *Definition, operands []int) string {
 	}
 
 	switch operandCount {
+	case 0:
+		return fmt.Sprintf("%s", def.Name)
 	case 1:
 		return fmt.Sprintf("%s %d", def.Name, operands[0])
 	}

--- a/pkg/code/code_test.go
+++ b/pkg/code/code_test.go
@@ -10,6 +10,7 @@ func TestMake(t *testing.T) {
 		expected []byte
 	}{
 		{OpConstant, []int{65534}, []byte{byte(OpConstant), 255, 254}},
+		{OpAdd, []int{}, []byte{byte(OpAdd)}},
 	}
 
 	for _, tt := range tests {
@@ -34,11 +35,13 @@ func TestInstructionsString(t *testing.T) {
 		Make(OpConstant, 1),
 		Make(OpConstant, 2),
 		Make(OpConstant, 65535),
+		Make(OpAdd),
 	}
 
 	expected := `0000 OpConstant 1
 0003 OpConstant 2
 0006 OpConstant 65535
+0009 OpAdd
 `
 
 	concatenated := Instructions{}

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -2,6 +2,8 @@
 package compiler
 
 import (
+	"fmt"
+
 	"github.com/freddiehaddad/monkey.compiler/pkg/code"
 	"github.com/freddiehaddad/monkey.interpreter/pkg/ast"
 	"github.com/freddiehaddad/monkey.interpreter/pkg/object"
@@ -42,6 +44,12 @@ func (c *Compiler) Compile(node ast.Node) error {
 		}
 		if err := c.Compile(node.Right); err != nil {
 			return err
+		}
+		switch node.Operator {
+		case "+":
+			c.emit(code.OpAdd)
+		default:
+			return fmt.Errorf("unknown operator %s", node.Operator)
 		}
 	case *ast.IntegerLiteral:
 		integer := &object.Integer{Value: node.Value}

--- a/pkg/compiler/compiler_test.go
+++ b/pkg/compiler/compiler_test.go
@@ -26,6 +26,7 @@ func TestIntegerArithmetic(t *testing.T) {
 			expectedInstructions: []code.Instructions{
 				code.Make(code.OpConstant, 0),
 				code.Make(code.OpConstant, 1),
+				code.Make(code.OpAdd),
 			},
 		},
 	}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -48,6 +48,13 @@ func (vm *VM) Run() error {
 			if err := vm.push(vm.constants[constIndex]); err != nil {
 				return err
 			}
+		case code.OpAdd:
+			rValue := vm.pop()
+			lValue := vm.pop()
+			rInteger := rValue.(*object.Integer).Value
+			lInteger := lValue.(*object.Integer).Value
+			sum := rInteger + lInteger
+			vm.push(&object.Integer{Value: sum})
 		}
 	}
 	return nil
@@ -62,4 +69,10 @@ func (vm *VM) push(o object.Object) error {
 	vm.sp++
 
 	return nil
+}
+
+func (vm *VM) pop() object.Object {
+	o := vm.stack[vm.sp-1]
+	vm.sp--
+	return o
 }

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -73,7 +73,7 @@ func TestIntegerArithmetic(t *testing.T) {
 	tests := []vmTestCase{
 		{"1", 1},
 		{"2", 2},
-		{"1 + 2", 2}, // FIXME
+		{"1 + 2", 3},
 	}
 
 	runVmTests(t, tests)


### PR DESCRIPTION
The `OpAdd` instruction introduced in this commit works by popping two
integer operands from the stack (right and left), adding them together,
and pushing the sum onto the stack.

Unit tests updated to validate functionality of `OpAdd`.
