### PR TITLE
feat(stack-cleanup): do not leave the expression results on the stack

### DIFF
--- a/pkg/code/code.go
+++ b/pkg/code/code.go
@@ -18,11 +18,13 @@ type Definition struct {
 const (
 	OpConstant Opcode = iota
 	OpAdd
+	OpPop
 )
 
 var definitions = map[Opcode]*Definition{
 	OpConstant: {"OpConstant", []int{2}},
 	OpAdd:      {"OpAdd", []int{}},
+	OpPop:      {"OpPop", []int{}},
 }
 
 func Lookup(op byte) (*Definition, error) {

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -38,6 +38,7 @@ func (c *Compiler) Compile(node ast.Node) error {
 		if err := c.Compile(node.Expression); err != nil {
 			return err
 		}
+		c.emit(code.OpPop)
 	case *ast.InfixExpression:
 		if err := c.Compile(node.Left); err != nil {
 			return err

--- a/pkg/compiler/compiler_test.go
+++ b/pkg/compiler/compiler_test.go
@@ -21,12 +21,13 @@ type compilerTestCase struct {
 func TestIntegerArithmetic(t *testing.T) {
 	tests := []compilerTestCase{
 		{
-			input:             "1 + 2",
+			input:             "1; 2",
 			expectedConstants: []interface{}{1, 2},
 			expectedInstructions: []code.Instructions{
 				code.Make(code.OpConstant, 0),
+				code.Make(code.OpPop),
 				code.Make(code.OpConstant, 1),
-				code.Make(code.OpAdd),
+				code.Make(code.OpPop),
 			},
 		},
 	}

--- a/pkg/repl/repl.go
+++ b/pkg/repl/repl.go
@@ -46,7 +46,7 @@ func Start(in io.Reader, out io.Writer) {
 			continue
 		}
 
-		stackTop := machine.StackTop()
+		stackTop := machine.LastPoppedStackElement()
 		io.WriteString(out, stackTop.Inspect())
 		io.WriteString(out, "\n")
 	}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -29,13 +29,6 @@ func New(bytecode *compiler.Bytecode) *VM {
 	}
 }
 
-func (vm *VM) StackTop() object.Object {
-	if vm.sp == 0 {
-		return nil
-	}
-	return vm.stack[vm.sp-1]
-}
-
 func (vm *VM) Run() error {
 	for ip := 0; ip < len(vm.instructions); ip++ {
 		op := code.Opcode(vm.instructions[ip])
@@ -55,9 +48,15 @@ func (vm *VM) Run() error {
 			lInteger := lValue.(*object.Integer).Value
 			sum := rInteger + lInteger
 			vm.push(&object.Integer{Value: sum})
+		case code.OpPop:
+			vm.pop()
 		}
 	}
 	return nil
+}
+
+func (vm *VM) LastPoppedStackElement() object.Object {
+	return vm.stack[vm.sp]
 }
 
 func (vm *VM) push(o object.Object) error {

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -52,7 +52,7 @@ func runVmTests(t *testing.T, tests []vmTestCase) {
 			t.Fatalf("vm error: %s", err)
 		}
 
-		stackElem := vm.StackTop()
+		stackElem := vm.LastPoppedStackElement()
 
 		testExpectedObject(t, tt.expected, stackElem)
 	}


### PR DESCRIPTION
Expressions should not be reused by definition.  Thus, keeping the value
on the stack is wrong and will lead to eventual stack overflow.

It was originally implemented with the involuntary stack persistence for
early development and testing.  This is because we did not yet have an
instruction for popping a value from the stack.
