### PR TITLE
feat(booleans): add support for boolean values

### DIFF
--- a/pkg/code/code.go
+++ b/pkg/code/code.go
@@ -18,6 +18,8 @@ type Definition struct {
 const (
 	OpConstant Opcode = iota
 	OpPop
+	OpTrue
+	OpFalse
 	OpAdd
 	OpSub
 	OpMul
@@ -27,6 +29,8 @@ const (
 var definitions = map[Opcode]*Definition{
 	OpConstant: {"OpConstant", []int{2}},
 	OpPop:      {"OpPop", []int{}},
+	OpTrue:     {"OpTrue", []int{}},
+	OpFalse:    {"OpFalse", []int{}},
 	OpAdd:      {"OpAdd", []int{}},
 	OpSub:      {"OpSub", []int{}},
 	OpMul:      {"OpMul", []int{}},

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -61,6 +61,12 @@ func (c *Compiler) Compile(node ast.Node) error {
 	case *ast.IntegerLiteral:
 		integer := &object.Integer{Value: node.Value}
 		c.emit(code.OpConstant, c.addConstant(integer))
+	case *ast.Boolean:
+		if node.Value {
+			c.emit(code.OpTrue)
+		} else {
+			c.emit(code.OpFalse)
+		}
 	}
 
 	return nil

--- a/pkg/compiler/compiler_test.go
+++ b/pkg/compiler/compiler_test.go
@@ -18,6 +18,29 @@ type compilerTestCase struct {
 	expectedInstructions []code.Instructions
 }
 
+func TestBooleanExpression(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input:             "true",
+			expectedConstants: []interface{}{},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpTrue),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             "false",
+			expectedConstants: []interface{}{},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpFalse),
+				code.Make(code.OpPop),
+			},
+		},
+	}
+
+	runCompilerTests(t, tests)
+}
+
 func TestIntegerArithmetic(t *testing.T) {
 	tests := []compilerTestCase{
 		{

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -11,6 +11,9 @@ import (
 
 const StackSize = 2048
 
+var True = &object.Boolean{Value: true}
+var False = &object.Boolean{Value: false}
+
 type VM struct {
 	constants    []object.Object
 	instructions code.Instructions
@@ -41,6 +44,14 @@ func (vm *VM) Run() error {
 			ip += 2
 
 			if err := vm.push(vm.constants[constIndex]); err != nil {
+				return err
+			}
+		case code.OpTrue:
+			if err := vm.push(True); err != nil {
+				return err
+			}
+		case code.OpFalse:
+			if err := vm.push(False); err != nil {
 				return err
 			}
 		case code.OpAdd, code.OpSub, code.OpMul, code.OpDiv:

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -36,6 +36,21 @@ func testIntegerObject(expected int64, actual object.Object) error {
 	return nil
 }
 
+func testBooleanObject(expected bool, actual object.Object) error {
+	result, ok := actual.(*object.Boolean)
+	if !ok {
+		return fmt.Errorf("object is not Boolean. got=%T (%+v)",
+			actual, actual)
+	}
+
+	if result.Value != expected {
+		return fmt.Errorf("object has wrong value. got=%t, want=%t",
+			result.Value, expected)
+	}
+
+	return nil
+}
+
 func runVmTests(t *testing.T, tests []vmTestCase) {
 	t.Helper()
 
@@ -66,6 +81,12 @@ func testExpectedObject(t *testing.T, expected interface{}, actual object.Object
 		if err := testIntegerObject(int64(expected), actual); err != nil {
 			t.Errorf("testIntegerObject failed: %s", err)
 		}
+	case bool:
+		if err := testBooleanObject(expected, actual); err != nil {
+			t.Errorf("testBooleanObject failed: %s", err)
+		}
+	default:
+		t.Errorf("unsupported type encountered: %T (%+v)", expected, expected)
 	}
 }
 
@@ -80,6 +101,15 @@ func TestIntegerArithmetic(t *testing.T) {
 		{"2 * 2 * 2 * 2 * 2", 32},
 		{"5 + 2 * 10", 25},
 		{"5 * (2 + 10)", 60},
+	}
+
+	runVmTests(t, tests)
+}
+
+func TestBooleanExpressions(t *testing.T) {
+	tests := []vmTestCase{
+		{"true", true},
+		{"false", false},
 	}
 
 	runVmTests(t, tests)


### PR DESCRIPTION
Compiling and executing Booleans is now supported.  Both True and False
variables have been declared in the `vm` package for performance
reasons.  There is no need to create a new object each time.
