### PR TITLE
feat(comparison-operators): add support for comparison operations

### DIFF
--- a/pkg/code/code.go
+++ b/pkg/code/code.go
@@ -17,24 +17,40 @@ type Definition struct {
 
 const (
 	OpConstant Opcode = iota
+
 	OpPop
+
 	OpTrue
 	OpFalse
+
 	OpAdd
 	OpSub
 	OpMul
 	OpDiv
+
+	OpEqual
+	OpNotEqual
+	OpLessThan
+	OpGreaterThan
 )
 
 var definitions = map[Opcode]*Definition{
 	OpConstant: {"OpConstant", []int{2}},
-	OpPop:      {"OpPop", []int{}},
-	OpTrue:     {"OpTrue", []int{}},
-	OpFalse:    {"OpFalse", []int{}},
-	OpAdd:      {"OpAdd", []int{}},
-	OpSub:      {"OpSub", []int{}},
-	OpMul:      {"OpMul", []int{}},
-	OpDiv:      {"OpDiv", []int{}},
+
+	OpPop: {"OpPop", []int{}},
+
+	OpTrue:  {"OpTrue", []int{}},
+	OpFalse: {"OpFalse", []int{}},
+
+	OpAdd: {"OpAdd", []int{}},
+	OpSub: {"OpSub", []int{}},
+	OpMul: {"OpMul", []int{}},
+	OpDiv: {"OpDiv", []int{}},
+
+	OpEqual:       {"OpEqual", []int{}},
+	OpNotEqual:    {"OpNotEqual", []int{}},
+	OpLessThan:    {"OpLessThan", []int{}},
+	OpGreaterThan: {"OpGreaterThan", []int{}},
 }
 
 func Lookup(op byte) (*Definition, error) {

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -55,6 +55,14 @@ func (c *Compiler) Compile(node ast.Node) error {
 			c.emit(code.OpMul)
 		case "/":
 			c.emit(code.OpDiv)
+		case "==":
+			c.emit(code.OpEqual)
+		case "!=":
+			c.emit(code.OpNotEqual)
+		case "<":
+			c.emit(code.OpLessThan)
+		case ">":
+			c.emit(code.OpGreaterThan)
 		default:
 			return fmt.Errorf("unknown operator %s", node.Operator)
 		}

--- a/pkg/compiler/compiler_test.go
+++ b/pkg/compiler/compiler_test.go
@@ -18,6 +18,73 @@ type compilerTestCase struct {
 	expectedInstructions []code.Instructions
 }
 
+func TestComparisonOperators(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input:             "10 == 10",
+			expectedConstants: []interface{}{10, 10},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpEqual),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             "10 != 10",
+			expectedConstants: []interface{}{10, 10},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpNotEqual),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             "true == true",
+			expectedConstants: []interface{}{},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpTrue),
+				code.Make(code.OpTrue),
+				code.Make(code.OpEqual),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             "true != false",
+			expectedConstants: []interface{}{},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpTrue),
+				code.Make(code.OpFalse),
+				code.Make(code.OpNotEqual),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             "1 < 2",
+			expectedConstants: []interface{}{1, 2},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpLessThan),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             "1 > 2",
+			expectedConstants: []interface{}{1, 2},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpGreaterThan),
+				code.Make(code.OpPop),
+			},
+		},
+	}
+
+	runCompilerTests(t, tests)
+}
+
 func TestBooleanExpression(t *testing.T) {
 	tests := []compilerTestCase{
 		{

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -90,6 +90,26 @@ func testExpectedObject(t *testing.T, expected interface{}, actual object.Object
 	}
 }
 
+func TestComparisonOperators(t *testing.T) {
+	tests := []vmTestCase{
+		{"10 == 10", true},
+		{"10 != 10", false},
+		{"true == true", true},
+		{"true == false", false},
+		{"true != false", true},
+		{"1 < 2", true},
+		{"2 < 1", false},
+		{"2 > 1", true},
+		{"1 > 2", false},
+		{"(1 < 2) == true", true},
+		{"(1 < 2) == false", false},
+		{"(1 > 2) == true", false},
+		{"(1 > 2) == false", true},
+	}
+
+	runVmTests(t, tests)
+}
+
 func TestIntegerArithmetic(t *testing.T) {
 	tests := []vmTestCase{
 		{"1", 1},


### PR DESCRIPTION
Comparisons include `==`, `!=`, `<`, and `>`.  Integer data types
support all four operators while non-integer types support equality
operators.
