### PR TITLE
feat(prefix-expressions): add support for `-` and `!` operators

### DIFF
--- a/pkg/code/code.go
+++ b/pkg/code/code.go
@@ -23,6 +23,9 @@ const (
 	OpTrue
 	OpFalse
 
+	OpBang
+	OpMinus
+
 	OpAdd
 	OpSub
 	OpMul
@@ -38,6 +41,9 @@ var definitions = map[Opcode]*Definition{
 	OpConstant: {"OpConstant", []int{2}},
 
 	OpPop: {"OpPop", []int{}},
+
+	OpBang:  {"OpBang", []int{}},
+	OpMinus: {"OpMinus", []int{}},
 
 	OpTrue:  {"OpTrue", []int{}},
 	OpFalse: {"OpFalse", []int{}},

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -66,6 +66,18 @@ func (c *Compiler) Compile(node ast.Node) error {
 		default:
 			return fmt.Errorf("unknown operator %s", node.Operator)
 		}
+	case *ast.PrefixExpression:
+		if err := c.Compile(node.Right); err != nil {
+			return err
+		}
+		switch node.Operator {
+		case "!":
+			c.emit(code.OpBang)
+		case "-":
+			c.emit(code.OpMinus)
+		default:
+			return fmt.Errorf("unknown prefix operator %s", node.Operator)
+		}
 	case *ast.IntegerLiteral:
 		integer := &object.Integer{Value: node.Value}
 		c.emit(code.OpConstant, c.addConstant(integer))

--- a/pkg/compiler/compiler_test.go
+++ b/pkg/compiler/compiler_test.go
@@ -85,7 +85,7 @@ func TestComparisonOperators(t *testing.T) {
 	runCompilerTests(t, tests)
 }
 
-func TestBooleanExpression(t *testing.T) {
+func TestBooleanExpressions(t *testing.T) {
 	tests := []compilerTestCase{
 		{
 			input:             "true",
@@ -100,6 +100,15 @@ func TestBooleanExpression(t *testing.T) {
 			expectedConstants: []interface{}{},
 			expectedInstructions: []code.Instructions{
 				code.Make(code.OpFalse),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             "!true",
+			expectedConstants: []interface{}{},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpTrue),
+				code.Make(code.OpBang),
 				code.Make(code.OpPop),
 			},
 		},
@@ -147,6 +156,15 @@ func TestIntegerArithmetic(t *testing.T) {
 				code.Make(code.OpConstant, 0),
 				code.Make(code.OpConstant, 1),
 				code.Make(code.OpDiv),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             "-1",
+			expectedConstants: []interface{}{1},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpMinus),
 				code.Make(code.OpPop),
 			},
 		},

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -58,9 +58,43 @@ func (vm *VM) Run() error {
 			vm.executeBinaryOperation(op)
 		case code.OpEqual, code.OpNotEqual, code.OpLessThan, code.OpGreaterThan:
 			vm.executeComparison(op)
+		case code.OpBang:
+			if err := vm.executeBangOperator(); err != nil {
+				return err
+			}
+		case code.OpMinus:
+			if err := vm.executeMinusOperator(); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unhandled instruction %T (%+v)", op, op)
 		}
 	}
 	return nil
+}
+
+func (vm *VM) executeMinusOperator() error {
+	operand := vm.pop()
+
+	if operand.Type() != object.INTEGER_OBJ {
+		return fmt.Errorf("unsupported type for negation: %s", operand.Type())
+	}
+
+	value := operand.(*object.Integer).Value
+	return vm.push(&object.Integer{Value: -value})
+}
+
+func (vm *VM) executeBangOperator() error {
+	operand := vm.pop()
+
+	switch operand {
+	case True:
+		return vm.push(False)
+	case False:
+		return vm.push(True)
+	default:
+		return vm.push(False)
+	}
 }
 
 func (vm *VM) executeComparison(op code.Opcode) error {

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -121,6 +121,10 @@ func TestIntegerArithmetic(t *testing.T) {
 		{"2 * 2 * 2 * 2 * 2", 32},
 		{"5 + 2 * 10", 25},
 		{"5 * (2 + 10)", 60},
+		{"-5", -5},
+		{"-15", -15},
+		{"-50 + 100 + -50", 0},
+		{"(5 + 10 * 2 + 15 / 3) * 2 + -10", 50},
 	}
 
 	runVmTests(t, tests)
@@ -130,6 +134,11 @@ func TestBooleanExpressions(t *testing.T) {
 	tests := []vmTestCase{
 		{"true", true},
 		{"false", false},
+		{"!true", false},
+		{"!false", true},
+		{"!!true", true},
+		{"!!false", false},
+		{"!!5", true},
 	}
 
 	runVmTests(t, tests)


### PR DESCRIPTION
The minus (negation) operator only works for integer data types.  (i.e.
`5` becomes `-5`).

The bang operator works for booleans as well as most other types.
Truthiness is defined as anything not explicitly `0` or `false` is true.
