### PR TITLE
feat(globals): add support for global variables and persistent state

### DIFF
--- a/pkg/code/code.go
+++ b/pkg/code/code.go
@@ -40,6 +40,9 @@ const (
 	OpNotEqual
 	OpLessThan
 	OpGreaterThan
+
+	OpGetGlobal
+	OpSetGlobal
 )
 
 var definitions = map[Opcode]*Definition{
@@ -67,6 +70,9 @@ var definitions = map[Opcode]*Definition{
 	OpNotEqual:    {"OpNotEqual", []int{}},
 	OpLessThan:    {"OpLessThan", []int{}},
 	OpGreaterThan: {"OpGreaterThan", []int{}},
+
+	OpGetGlobal: {"OpGetGlobal", []int{2}},
+	OpSetGlobal: {"OpSetGlobal", []int{2}},
 }
 
 func Lookup(op byte) (*Definition, error) {

--- a/pkg/compiler/compiler_test.go
+++ b/pkg/compiler/compiler_test.go
@@ -18,6 +18,55 @@ type compilerTestCase struct {
 	expectedInstructions []code.Instructions
 }
 
+func TestGlobalLetStatements(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input: `
+				let one = 1;
+				let two = 2;
+			`,
+			expectedConstants: []interface{}{1, 2},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpSetGlobal, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpSetGlobal, 1),
+			},
+		},
+		{
+			input: `
+				let one = 1;
+				one;
+			`,
+			expectedConstants: []interface{}{1},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpSetGlobal, 0),
+				code.Make(code.OpGetGlobal, 0),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input: `
+				let one = 1;
+				let two = one;
+				two;
+			`,
+			expectedConstants: []interface{}{1},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpSetGlobal, 0),
+				code.Make(code.OpGetGlobal, 0),
+				code.Make(code.OpSetGlobal, 1),
+				code.Make(code.OpGetGlobal, 1),
+				code.Make(code.OpPop),
+			},
+		},
+	}
+
+	runCompilerTests(t, tests)
+}
+
 func TestConditionals(t *testing.T) {
 	tests := []compilerTestCase{
 		{

--- a/pkg/compiler/symbol_table.go
+++ b/pkg/compiler/symbol_table.go
@@ -1,0 +1,36 @@
+// The Monkey Language compiler symbol table
+package compiler
+
+type SymbolScope string
+
+const (
+	GlobalScope SymbolScope = "GLOBAL"
+)
+
+type Symbol struct {
+	Name  string
+	Scope SymbolScope
+	Index int
+}
+
+type SymbolTable struct {
+	store          map[string]Symbol
+	numDefinitions int
+}
+
+func NewSymbolTable() *SymbolTable {
+	s := make(map[string]Symbol)
+	return &SymbolTable{store: s}
+}
+
+func (s *SymbolTable) Define(name string) Symbol {
+	symbol := Symbol{Name: name, Index: s.numDefinitions, Scope: GlobalScope}
+	s.store[name] = symbol
+	s.numDefinitions++
+	return symbol
+}
+
+func (s *SymbolTable) Resolve(name string) (Symbol, bool) {
+	obj, ok := s.store[name]
+	return obj, ok
+}

--- a/pkg/compiler/symbol_table_test.go
+++ b/pkg/compiler/symbol_table_test.go
@@ -1,0 +1,43 @@
+// The Monkey Language compiler symbol table tests
+package compiler
+
+import "testing"
+
+func TestDefine(t *testing.T) {
+	expected := map[string]Symbol{
+		"a": {Name: "a", Scope: GlobalScope, Index: 0},
+		"b": {Name: "b", Scope: GlobalScope, Index: 1},
+	}
+
+	global := NewSymbolTable()
+
+	if a := global.Define("a"); a != expected["a"] {
+		t.Errorf("expected a=%+v, got=%+v", expected["a"], a)
+	}
+
+	if b := global.Define("b"); b != expected["b"] {
+		t.Errorf("expected b=%+v, got=%+v", expected["b"], b)
+	}
+}
+
+func TestResolveGlobal(t *testing.T) {
+	global := NewSymbolTable()
+	global.Define("a")
+	global.Define("b")
+
+	expected := []Symbol{
+		{Name: "a", Scope: GlobalScope, Index: 0},
+		{Name: "b", Scope: GlobalScope, Index: 1},
+	}
+
+	for _, sym := range expected {
+		result, ok := global.Resolve(sym.Name)
+		if !ok {
+			t.Errorf("name %s not resolvable", sym.Name)
+			continue
+		}
+		if result != sym {
+			t.Errorf("expected %s to resolve to %+v, got=%+v", sym.Name, sym, result)
+		}
+	}
+}

--- a/pkg/repl/repl.go
+++ b/pkg/repl/repl.go
@@ -9,6 +9,7 @@ import (
 	"github.com/freddiehaddad/monkey.compiler/pkg/compiler"
 	"github.com/freddiehaddad/monkey.compiler/pkg/vm"
 	"github.com/freddiehaddad/monkey.interpreter/pkg/lexer"
+	"github.com/freddiehaddad/monkey.interpreter/pkg/object"
 	"github.com/freddiehaddad/monkey.interpreter/pkg/parser"
 )
 
@@ -16,6 +17,10 @@ const PROMPT = "> "
 
 func Start(in io.Reader, out io.Writer) {
 	scanner := bufio.NewScanner(in)
+
+	constants := []object.Object{}
+	symbolTable := compiler.NewSymbolTable()
+	globals := make([]object.Object, vm.GlobalSize)
 
 	for {
 		fmt.Fprintf(out, PROMPT)
@@ -34,13 +39,13 @@ func Start(in io.Reader, out io.Writer) {
 			continue
 		}
 
-		compiler := compiler.New()
+		compiler := compiler.NewWithState(symbolTable, constants)
 		if err := compiler.Compile(program); err != nil {
 			fmt.Fprintf(out, "Woops! Compilation failed:\n %s\n", err)
 			continue
 		}
 
-		machine := vm.New(compiler.Bytecode())
+		machine := vm.NewWithState(compiler.Bytecode(), globals)
 		if err := machine.Run(); err != nil {
 			fmt.Fprintf(out, "Woops! Executing bytecode failed:\n %s\n", err)
 			continue

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -165,3 +165,13 @@ func TestConditionals(t *testing.T) {
 
 	runVmTests(t, tests)
 }
+
+func TestGlobalLetStatements(t *testing.T) {
+	tests := []vmTestCase{
+		{"let one = 1; one", 1},
+		{"let one = 1; let two = 2; one + two", 3},
+		{"let one = 1; let two = one + one; one + two", 3},
+	}
+
+	runVmTests(t, tests)
+}


### PR DESCRIPTION
Global let statements leverage the newly defined global symbol table and
necessary opcodes for defining and resolving symbols.

The symbol table and methods for defining and resolving symbols along
with unit tests are created.  Initial support exists for global
variables with other scopes coming later.

The new op codes convert string identifiers internally into indexes into
a global memory array.  The instructions encode the index into the array
when storing and retrieving global variables.

New methods for creating a compiler and vm were added to specify the
global, constant, and symbol tables as arguments to the compiler and vm.
From the REPL, previous values stored in memory need to exist when
compiling new instructions.

Otherwise, code such as the following would fail since `a` no longer
exists in the new compiler and vm state.

    let a = 3
    a
