### PR TITLE
feat(strings): support strings and string concatenation

### DIFF
--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -157,6 +157,9 @@ func (c *Compiler) Compile(node ast.Node) error {
 			return fmt.Errorf("undefined identifier %s", node.Value)
 		}
 		c.emit(code.OpGetGlobal, symbol.Index)
+	case *ast.StringLiteral:
+		string := &object.String{Value: node.Value}
+		c.emit(code.OpConstant, c.addConstant(string))
 	case *ast.IntegerLiteral:
 		integer := &object.Integer{Value: node.Value}
 		c.emit(code.OpConstant, c.addConstant(integer))

--- a/pkg/compiler/compiler_test.go
+++ b/pkg/compiler/compiler_test.go
@@ -18,6 +18,31 @@ type compilerTestCase struct {
 	expectedInstructions []code.Instructions
 }
 
+func TestStringExpressions(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input:             `"monkey"`,
+			expectedConstants: []interface{}{"monkey"},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             `"mon" + "key"`,
+			expectedConstants: []interface{}{"mon", "key"},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpAdd),
+				code.Make(code.OpPop),
+			},
+		},
+	}
+
+	runCompilerTests(t, tests)
+}
+
 func TestGlobalLetStatements(t *testing.T) {
 	tests := []compilerTestCase{
 		{
@@ -339,6 +364,12 @@ func testConstants(t *testing.T, expected []interface{}, actual []object.Object)
 			if err := testIntegerObject(int64(constant), actual[i]); err != nil {
 				return fmt.Errorf("constant %d - testIntegerObject failed: %s", i, err)
 			}
+		case string:
+			if err := testStringObject(constant, actual[i]); err != nil {
+				return fmt.Errorf("constant %d - testStringObject failed: %s", i, err)
+			}
+		default:
+			return fmt.Errorf("testConstants failed: unhandled type (%T)", constant)
 		}
 	}
 	return nil
@@ -352,6 +383,19 @@ func testIntegerObject(expected int64, actual object.Object) error {
 
 	if result.Value != expected {
 		return fmt.Errorf("object has wrong value. got=%d, want=%d", result.Value, expected)
+	}
+
+	return nil
+}
+
+func testStringObject(expected string, actual object.Object) error {
+	result, ok := actual.(*object.String)
+	if !ok {
+		return fmt.Errorf("object is not string. got=%T (%+v)", actual, actual)
+	}
+
+	if result.Value != expected {
+		return fmt.Errorf("object has wrong value. got=%s, want=%s", result.Value, expected)
 	}
 
 	return nil

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -188,6 +188,10 @@ func (vm *VM) executeBinaryOperation(op code.Opcode) error {
 		return vm.executeBinaryIntegerOberation(op, left, right)
 	}
 
+	if leftType == object.STRING_OBJ && rightType == object.STRING_OBJ {
+		return vm.executeBinaryStringOperation(op, left, right)
+	}
+
 	return fmt.Errorf("unsupported types for binary operation: %s %s",
 		leftType, rightType)
 }
@@ -242,6 +246,24 @@ func (vm *VM) executeBinaryIntegerOberation(
 	}
 
 	return vm.push(&object.Integer{Value: result})
+}
+
+func (vm *VM) executeBinaryStringOperation(
+	op code.Opcode, left, right object.Object) error {
+
+	lValue := left.(*object.String).Value
+	rValue := right.(*object.String).Value
+
+	var result string
+
+	switch op {
+	case code.OpAdd:
+		result = lValue + rValue
+	default:
+		return fmt.Errorf("unknown interger operator: %d", op)
+	}
+
+	return vm.push(&object.String{Value: result})
 }
 
 func (vm *VM) LastPoppedStackElement() object.Object {

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -51,6 +51,21 @@ func testBooleanObject(expected bool, actual object.Object) error {
 	return nil
 }
 
+func testStringObject(expected string, actual object.Object) error {
+	result, ok := actual.(*object.String)
+	if !ok {
+		return fmt.Errorf("object is not String. got=%T (%+v)",
+			actual, actual)
+	}
+
+	if result.Value != expected {
+		return fmt.Errorf("object has wrong value. got=%s, want=%s",
+			result.Value, expected)
+	}
+
+	return nil
+}
+
 func runVmTests(t *testing.T, tests []vmTestCase) {
 	t.Helper()
 
@@ -84,6 +99,10 @@ func testExpectedObject(t *testing.T, expected interface{}, actual object.Object
 	case bool:
 		if err := testBooleanObject(expected, actual); err != nil {
 			t.Errorf("testBooleanObject failed: %s", err)
+		}
+	case string:
+		if err := testStringObject(expected, actual); err != nil {
+			t.Errorf("testStringObject failed: %s", err)
 		}
 	case *object.Null:
 		if actual != Null {
@@ -171,6 +190,16 @@ func TestGlobalLetStatements(t *testing.T) {
 		{"let one = 1; one", 1},
 		{"let one = 1; let two = 2; one + two", 3},
 		{"let one = 1; let two = one + one; one + two", 3},
+	}
+
+	runVmTests(t, tests)
+}
+
+func TestStringExpressions(t *testing.T) {
+	tests := []vmTestCase{
+		{`"monkey"`, "monkey"},
+		{`"mon" + "key"`, "monkey"},
+		{`"mon" + "key" + "banana"`, "monkeybanana"},
 	}
 
 	runVmTests(t, tests)


### PR DESCRIPTION
`string` literal objects are treated as constants and do not require the
implementation of a new op code.  Concatenation of `string` objects is
handled via the `OpAdd` op code.
