### PR TITLE
feat(hash): add support for hash tables (maps)

### DIFF
--- a/pkg/code/code.go
+++ b/pkg/code/code.go
@@ -45,6 +45,7 @@ const (
 	OpSetGlobal
 
 	OpArray
+	OpHash
 )
 
 var definitions = map[Opcode]*Definition{
@@ -77,6 +78,7 @@ var definitions = map[Opcode]*Definition{
 	OpSetGlobal: {"OpSetGlobal", []int{2}},
 
 	OpArray: {"OpArray", []int{2}},
+	OpHash:  {"OpHash", []int{2}},
 }
 
 func Lookup(op byte) (*Definition, error) {

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -164,6 +164,16 @@ func (c *Compiler) Compile(node ast.Node) error {
 			}
 		}
 		c.emit(code.OpArray, len(node.Elements))
+	case *ast.HashLiteral:
+		for k, v := range node.Pairs {
+			if err := c.Compile(k); err != nil {
+				return err
+			}
+			if err := c.Compile(v); err != nil {
+				return err
+			}
+		}
+		c.emit(code.OpHash, len(node.Pairs))
 	case *ast.StringLiteral:
 		string := &object.String{Value: node.Value}
 		c.emit(code.OpConstant, c.addConstant(string))

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -123,6 +123,27 @@ func testExpectedObject(t *testing.T, expected interface{}, actual object.Object
 				t.Errorf("testIntegerObject failed: %s", err)
 			}
 		}
+	case map[object.HashKey]int64:
+		hash, ok := actual.(*object.Hash)
+		if !ok {
+			t.Errorf("object not Hash: %T (%+v)", actual, actual)
+			return
+		}
+		if len(hash.Pairs) != len(expected) {
+			t.Errorf("hash has wrong number of Pairs. want=%d, got=%d",
+				len(expected), len(hash.Pairs))
+			return
+		}
+		for expectedKey, expectedValue := range expected {
+			pair, ok := hash.Pairs[expectedKey]
+			if !ok {
+				t.Errorf("no pair for given key in Pairs")
+			}
+
+			if err := testIntegerObject(expectedValue, pair.Value); err != nil {
+				t.Errorf("testIntegerObject failed: %s", err)
+			}
+		}
 	default:
 		t.Errorf("unsupported type encountered: %T (%+v)", expected, expected)
 	}
@@ -225,6 +246,55 @@ func TestArrayLiterals(t *testing.T) {
 		{"[]", []int{}},
 		{"[1, 2, 3]", []int{1, 2, 3}},
 		{"[1 + 2, 3 * 4, 5 + 6]", []int{3, 12, 11}},
+	}
+
+	runVmTests(t, tests)
+}
+
+func TestHashLiterals(t *testing.T) {
+	tests := []vmTestCase{
+		{
+			"{}",
+			map[object.HashKey]int64{},
+		},
+		{
+			"{1: 2}",
+			map[object.HashKey]int64{
+				(&object.Integer{Value: 1}).HashKey(): 2,
+			},
+		},
+		{
+			"{1 + 2: 3}",
+			map[object.HashKey]int64{
+				(&object.Integer{Value: 3}).HashKey(): 3,
+			},
+		},
+		{
+			"{1: 2 + 3}",
+			map[object.HashKey]int64{
+				(&object.Integer{Value: 1}).HashKey(): 5,
+			},
+		},
+		{
+			"{0 + 1: 2 + 3}",
+			map[object.HashKey]int64{
+				(&object.Integer{Value: 1}).HashKey(): 5,
+			},
+		},
+		{
+			"{0: 1 + 2, 3: 4 + 5}",
+			map[object.HashKey]int64{
+				(&object.Integer{Value: 0}).HashKey(): 3,
+				(&object.Integer{Value: 3}).HashKey(): 9,
+			},
+		},
+		{
+			"{0 + 1: 2, 3 + 4: 5}",
+			map[object.HashKey]int64{
+				(&object.Integer{Value: 1}).HashKey(): 2,
+				(&object.Integer{Value: 7}).HashKey(): 5,
+			},
+		},
 	}
 
 	runVmTests(t, tests)


### PR DESCRIPTION
Like Arrays, the initial implementation supports the creation of hash
tables without the support for lookups.  Lookups will be implemented in
a future commit.
